### PR TITLE
feat: adds env-var configurable configuration (#261)

### DIFF
--- a/configuration/networks/disttestnetwork/configuration.js
+++ b/configuration/networks/disttestnetwork/configuration.js
@@ -1,0 +1,23 @@
+function asNumber(value) {
+  return parseInt(value);
+}
+
+module.exports = {
+  collateral: {
+    repairRewardPercentage: asNumber(process.env.DISTTEST_REPAIRREWARD),
+    maxNumberOfSlashes: asNumber(process.env.DISTTEST_MAXSLASHES),
+    slashPercentage: asNumber(process.env.DISTTEST_SLASHPERCENTAGE),
+    validatorRewardPercentage: asNumber(process.env.DISTTEST_VALIDATORREWARD),
+  },
+  proofs: {
+    period: asNumber(process.env.DISTTEST_PERIOD),
+    timeout: asNumber(process.env.DISTTEST_TIMEOUT),
+    downtime: asNumber(process.env.DISTTEST_DOWNTIME),
+    downtimeProduct: asNumber(process.env.DISTTEST_DOWNTIMEPRODUCT),
+    zkeyHash: "",
+  },
+  reservations: {
+    maxReservations: asNumber(process.env.DISTTEST_MAXRESERVATIONS),
+  },
+  requestDurationLimit: asNumber(process.env.DISTTEST_MAXDURATION)
+}


### PR DESCRIPTION
PR is a `git cherry-pick da1400ce9a65c3695d7847f7ca8e3386a5a189c8` of the missed commit and with a network name adjustment.

And an author comment
> There's an issue in the tests that is caused by misconfigured marketplace deployment, because the block frequency is different. This is a step towards fixing these tests by allowing the tests to set the marketplace configuration values.