### PR TITLE
chore: re-link verifier disttestnetwork

### DIFF
--- a/verifier/networks/codexdisttestnetwork
+++ b/verifier/networks/codexdisttestnetwork
@@ -1,1 +1,0 @@
-codex_testnet

--- a/verifier/networks/disttestnetwork
+++ b/verifier/networks/disttestnetwork
@@ -1,0 +1,1 @@
+testnet


### PR DESCRIPTION
PR updates the `disttestnetwork` symlink to point to the existing `testnet`.

Old network `codexdisttestnetwork` symlink was removed.