### PR TITLE
feat: testnet configuration via env-vars with arbitrum adjusted defaults

### DIFF
--- a/configuration/networks/testnet/configuration.js
+++ b/configuration/networks/testnet/configuration.js
@@ -1,0 +1,23 @@
+function asNumber(value) {
+  return parseInt(value);
+}
+
+module.exports = {
+  collateral: {
+    repairRewardPercentage: asNumber(process.env.TESTNET_REPAIRREWARD ? process.env.TESTNET_REPAIRREWARD : 10),
+    maxNumberOfSlashes: asNumber(process.env.TESTNET_MAXSLASHES ? process.env.TESTNET_MAXSLASHES : 2),
+    slashPercentage: asNumber(process.env.TESTNET_SLASHPERCENTAGE ? process.env.TESTNET_SLASHPERCENTAGE : 20),
+    validatorRewardPercentage: asNumber(process.env.TESTNET_VALIDATORREWARD ? process.env.TESTNET_VALIDATORREWARD : 20),
+  },
+  proofs: {
+    period: asNumber(process.env.TESTNET_PERIOD ? process.env.TESTNET_PERIOD : 20),
+    timeout: asNumber(process.env.TESTNET_TIMEOUT ? process.env.TESTNET_TIMEOUT : 10),
+    downtime: asNumber(process.env.TESTNET_DOWNTIME ? process.env.TESTNET_DOWNTIME : 128),
+    downtimeProduct: asNumber(process.env.TESTNET_DOWNTIMEPRODUCT ? process.env.TESTNET_DOWNTIMEPRODUCT : 131),
+    zkeyHash: "",
+  },
+  reservations: {
+    maxReservations: asNumber(process.env.TESTNET_MAXRESERVATIONS ? process.env.TESTNET_MAXRESERVATIONS : 3),
+  },
+  requestDurationLimit: asNumber(process.env.TESTNET_MAXDURATION ? process.env.TESTNET_MAXDURATION : 60*60*24*30) // 30 days
+}


### PR DESCRIPTION
PR add specific configuration for Testnet deployments which were adjusted for Arbitrum.

We also, can adjust configuration using environment variables. Done based on the [configuration/networks/disttestnetwork](https://github.com/durability-labs/archivist-contracts/tree/main/configuration/networks/disttestnetwork).


<details><summary>Performed checks</summary>

We did use [Nitro Testnode](https://github.com/OffchainLabs/nitro-testnode) for local Artibrum and [Cast](https://github.com/foundry-rs/foundry#cast) from [Foundry](https://github.com/foundry-rs/foundry) for checks.

#### Current deployment - with defaults
```shell
cast decode-abi 'func(uint[])(uint[])' $(cast call --rpc-url https://rpc.testnet.archivist.storage 0x9fec9f5C5D6232E3cE55B92FC04758a41A528d2b "configuration()")

[2, 20, 20, 224, 3, 2592000 [2.592e6], 120, 30, 64, 67]
```

#### Local check 1 - Testnet with network specific defaults
```shell
export ARCHIVIST_TESTNET_URL="http://localhost:8547"

# Deploy
npm run deploy -- --network testnet --deployment-id testnet --reset

# Check
cast decode-abi 'func(uint[])(uint[])' $(cast call --rpc-url http://localhost:8547 0x83e214114E6067862211FFc3FAbcf35C1C9Ac21b "configuration()")

[2, 20, 20, 224, 3, 2592000 [2.592e6], 20, 10, 128, 131]
```

#### Local check 2 - Testnet with custom values
```shell
export ARCHIVIST_TESTNET_URL="http://localhost:8547"
export TESTNET_DOWNTIME=150
export TESTNET_DOWNTIMEPRODUCT=170

# Deploy
npm run deploy -- --network testnet --deployment-id testnet --reset

# Check
cast decode-abi 'func(uint[])(uint[])' $(cast call --rpc-url http://localhost:8547 0x3fD6AFeef805Be53A0821df443304D0b85CACf88 "configuration()")

[2, 20, 20, 224, 3, 2592000 [2.592e6], 20, 10, 150, 170]
```
</details>