### PR TITLE
fix: proof period parameters for arbitrum and hardhat

### DIFF
--- a/configuration/configuration.js
+++ b/configuration/configuration.js
@@ -10,11 +10,11 @@ const DEFAULT_CONFIGURATION = {
     validatorRewardPercentage: 20, // percentage of the slashed amount going to the validators
   },
   proofs: {
-    // period has to be less than downtime * blocktime
-    period: 20, // seconds
-    timeout: 10, // seconds
-    downtime: 128, // number of blocks
-    downtimeProduct: 131, // number of blocks
+    // period + timeout has to be less than downtime * blocktime
+    period: 300, // seconds
+    timeout: 60, // seconds
+    downtime: 32, // number of blocks
+    downtimeProduct: 37, // number of blocks
     zkeyHash: "",
   },
   reservations: {

--- a/configuration/networks/devnet/configuration.js
+++ b/configuration/networks/devnet/configuration.js
@@ -10,10 +10,10 @@ module.exports = {
     validatorRewardPercentage: asNumber(process.env.DEVNET_VALIDATORREWARD ? process.env.DEVNET_VALIDATORREWARD : 20),
   },
   proofs: {
-    period: asNumber(process.env.DEVNET_PERIOD ? process.env.DEVNET_PERIOD : 20),
-    timeout: asNumber(process.env.DEVNET_TIMEOUT ? process.env.DEVNET_TIMEOUT : 10),
-    downtime: asNumber(process.env.DEVNET_DOWNTIME ? process.env.DEVNET_DOWNTIME : 128),
-    downtimeProduct: asNumber(process.env.DEVNET_DOWNTIMEPRODUCT ? process.env.DEVNET_DOWNTIMEPRODUCT : 131),
+    period: asNumber(process.env.DEVNET_PERIOD ? process.env.DEVNET_PERIOD : 300),
+    timeout: asNumber(process.env.DEVNET_TIMEOUT ? process.env.DEVNET_TIMEOUT : 60),
+    downtime: asNumber(process.env.DEVNET_DOWNTIME ? process.env.DEVNET_DOWNTIME : 32),
+    downtimeProduct: asNumber(process.env.DEVNET_DOWNTIMEPRODUCT ? process.env.DEVNET_DOWNTIMEPRODUCT : 37),
     zkeyHash: "",
   },
   reservations: {

--- a/configuration/networks/localhost/configuration.js
+++ b/configuration/networks/localhost/configuration.js
@@ -6,9 +6,9 @@ module.exports = {
     validatorRewardPercentage: 20, // percentage of the slashed amount going to the validators
   },
   proofs: {
-    // period has to be less than downtime * blocktime
+    // period + timeout has to be less than downtime * blocktime
     // blocktime can be 1 second with hardhat in automine mode
-    period: 20, // seconds
+    period: 60, // seconds
     timeout: 10, // seconds
     downtime: 128, // number of blocks
     downtimeProduct: 131, // number of blocks

--- a/configuration/networks/testnet/configuration.js
+++ b/configuration/networks/testnet/configuration.js
@@ -10,10 +10,10 @@ module.exports = {
     validatorRewardPercentage: asNumber(process.env.TESTNET_VALIDATORREWARD ? process.env.TESTNET_VALIDATORREWARD : 20),
   },
   proofs: {
-    period: asNumber(process.env.TESTNET_PERIOD ? process.env.TESTNET_PERIOD : 20),
-    timeout: asNumber(process.env.TESTNET_TIMEOUT ? process.env.TESTNET_TIMEOUT : 10),
-    downtime: asNumber(process.env.TESTNET_DOWNTIME ? process.env.TESTNET_DOWNTIME : 128),
-    downtimeProduct: asNumber(process.env.TESTNET_DOWNTIMEPRODUCT ? process.env.TESTNET_DOWNTIMEPRODUCT : 131),
+    period: asNumber(process.env.TESTNET_PERIOD ? process.env.TESTNET_PERIOD : 300),
+    timeout: asNumber(process.env.TESTNET_TIMEOUT ? process.env.TESTNET_TIMEOUT : 60),
+    downtime: asNumber(process.env.TESTNET_DOWNTIME ? process.env.TESTNET_DOWNTIME : 32),
+    downtimeProduct: asNumber(process.env.TESTNET_DOWNTIMEPRODUCT ? process.env.TESTNET_DOWNTIMEPRODUCT : 37),
     zkeyHash: "",
   },
   reservations: {


### PR DESCRIPTION
Sets a 5 minute proof period on arbitrum testnet and devnet. Sets a 1 minute proof period for hardhat testing.

reasons:
- arbitrum evm uses block number and hashes from L1
- allow for about 5 proofs to be generated in a period in hardhat