### PR TITLE
ci(devnet-contracts): fix workflow

### DIFF
--- a/.github/workflows/devnet-contracts.yml
+++ b/.github/workflows/devnet-contracts.yml
@@ -72,7 +72,6 @@ jobs:
             aws s3 cp \
               --acl public-read \
               --content-type "text/plain" \
-              latest "s3://${bucket}/${network}/${record}"
               ${{ env.ADDRESS_TYPE }} s3://${bucket}/${network_path}/${{ env.ADDRESS_TYPE }}
           done
 


### PR DESCRIPTION
PR is a quick https://github.com/durability-labs/archivist-contracts/pull/12 followup to fix a workflow by removing a left copy-paste line.

That time run works as expected - [Devnet - Contracts deployment #2](https://github.com/durability-labs/archivist-contracts/actions/runs/18841483354).