### PR TITLE
ci(devnet-contracts): skip deployment artifacts commit

### DIFF
--- a/.github/workflows/devnet-contracts.yml
+++ b/.github/workflows/devnet-contracts.yml
@@ -80,6 +80,7 @@ jobs:
           HARDHAT_IGNITION_CONFIRM_DEPLOYMENT: false
 
       - name: Commit deployment artifacts
+        if: false
         uses: planetscale/ghcommit-action@v0.2.18
         with:
           commit_message: "chore(${{ env.NETWORK }}): contracts deployment artifacts\n${{ github.actor }}: ${{ github.event.head_commit.message }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
A quick https://github.com/durability-labs/archivist-contracts/pull/14 followup and it disable a step which commits deployments artifacts to a contracts repository `main` branch.

That needs to be elaborated more careful.