### PR TITLE
ci(testnet-contracts): adjust commit message and pr title

### DIFF
--- a/.github/workflows/testnet-contracts.yml
+++ b/.github/workflows/testnet-contracts.yml
@@ -241,12 +241,12 @@ jobs:
           branch-suffix: timestamp
           sign-commits: true
           commit-message: |
-            chore: ${{ env.NETWORK }} marketplace address updated [skip ci]
+            chore: ${{ env.NETWORK }} marketplace address updated [release]
 
             ${{ github.actor }} triggered from a ${{ github.ref_type }} ${{ github.ref_name }} ${{ needs.contracts-deploy.outputs.contracts_ref }}
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           base: ${{ env.ARCHIVIST_REPOSITORY_BRANCH }}
-          title: "chore: ${{ env.NETWORK }} marketplace address updated [skip ci]"
+          title: "chore: ${{ env.NETWORK }} marketplace address updated [release]"
           body: |
             Marketplace address update for ${{ env.NETWORK }}.
 


### PR DESCRIPTION
PR adjusts `testnet-contracts` workflow and change PR commit message and Title from the standard [`[skip ci]`](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs), we will use `[release]` which will be handled by the [archivist-node](https://github.com/durability-labs/archivist-node) repository workflows.

That is done, because when `[skip ci]` is used as a latest commit for a tag, GitHub Actions will not trigger workflow on the tags and we have to run release related workflows manually.